### PR TITLE
Block "Extend your trip" suggestions

### DIFF
--- a/booking-com-distraction-free.txt
+++ b/booking-com-distraction-free.txt
@@ -32,3 +32,6 @@ booking.com##p.urgency_message_x_people
 booking.com##div.bui-price-display__original
 booking.com##div.ge-wombat-benefits-block.genius_identity_refresh
 booking.com##div.fe_banner.fe_banner__accessible.fe_banner__red
+
+# Bookings & Trips page
+booking.com##.mltt__leg--suggestion


### PR DESCRIPTION
Thank you for this list :-)

I've noticed that [the `Your trip` overview](https://secure.booking.com/myreservations.html) extends your booked items with additional city suggestion, some even injected in the middle, nonsensically (back-tracking and zigzag).

With this filter, suggestions get removed.